### PR TITLE
Example: Tailnet only

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -6,7 +6,7 @@ chmod +w /opt/couchdb/data/persistence.ini
 mkdir -p /opt/couchdb/data/tailscale
 # TailScale
 echo "Starting TailScale"
-/app/tailscaled -tun=userspace-networking --statedir=/opt/couchdb/data/tailscale &
+/app/tailscaled -tun=userspace-networking --statedir=/var/lib/tailscale &
 /app/tailscale up --authkey=${TS_AUTHKEY} ${TS_EXTRA_ARGS} --hostname=${TS_HOSTNAME}
 /app/tailscale serve --bg http://localhost:5984
 

--- a/init.sh
+++ b/init.sh
@@ -8,6 +8,6 @@ mkdir -p /opt/couchdb/data/tailscale
 echo "Starting TailScale"
 /app/tailscaled -tun=userspace-networking --statedir=/opt/couchdb/data/tailscale &
 /app/tailscale up --authkey=${TS_AUTHKEY} ${TS_EXTRA_ARGS} --hostname=${TS_HOSTNAME}
-/app/tailscale funnel --bg http://localhost:5984
+/app/tailscale serve --bg http://localhost:5984
 
 echo "Starting CouchDB"

--- a/readme.md
+++ b/readme.md
@@ -1,14 +1,14 @@
-## The Single Dockerfile of CouchDB with Tailscale Funnel
+## The Single Dockerfile of CouchDB with Tailscale Serve
 
 
 ### What is this
 - CouchDB Server which configured about CORS for Obsidian and Self-hosted LiveSync in a **single Dockerfile**.
   - This enables you to bring your server to the Oracle Cloud, AWS App Runner, Google CloudRun or any other cloud Docker-PaaS services **without any domain and SSL Certificate**. Very thankfully, they have mostly free tiers.
-- Instead of your domain and SSL Certificate, This image uses [TailScale](https://tailscale.com/) Funnel. Also have free tier, tremendous thankfully!
+- Instead of your domain and SSL Certificate, This image uses [TailScale](https://tailscale.com/) Serve. Also have free tier, tremendous thankfully!
 
 ### Prerequisites
 You should have an account of Tailscale.
-Your Tailscale account should enabled Funnel once.
+Your Tailscale account should enabled Serve.
 
 (To more instructions, read the [official document](https://tailscale.com/blog/docker-tailscale-guide)).
 
@@ -25,25 +25,17 @@ You should make sure following Environment variables.
 | TS_HOSTNAME      | anything you like as `tailscaled-couchdb` (This would be a subdomain of your node)        |
 
 
-Note: If you are first to this, some interaction will be shown in the log. Please follow messages. 
+> **Note:** When you run the container for the first time, you may see interactive messages in the log. Please follow the instructions.
 
-```
-Funnel is enabled, but the list of allowed nodes in the tailnet policy file does not include the one you are using.
-To give access to this node you can edit the tailnet policy file, or visit:
-
-         https://login.tailscale.com/f/funnel?node=something random
-
-```
-
-And, if you have completed the configuration, following will also be shown.
+This version uses **Tailscale Serve** so that CouchDB is only accessible within your Tailnet. After successful configuration, you should see something like:
 
 ```
 Success.
-Available on the internet:
+Available on your Tailnet:
 
-https://{TS_HOSTNAME}.xxxxxxx.ts.net/
+https://{TS_HOSTNAME}.{tailnet-name}.ts.net/
 |-- proxy http://127.0.0.1:5984
 
 ```
 
-That's it. Enjoy your CouchDB with Tailscale Funnel.
+That's it. Enjoy your CouchDB with Tailscale Serve.


### PR DESCRIPTION
This PR shows how to use serve rather than funnel when the database should only be available to devices on the tailnet and not the public internet.

suggestion: add environment variable which lets the user select the mode

THANKS SO MUCH for providing this amazing repository!